### PR TITLE
Se agrega .gitignore para excluir archivos .log del repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignora todos los archivos .log del repositorio 
+*.log


### PR DESCRIPTION
Breve explicación de la correcta configuración del archivo .gitignore.

El asterisco (*) actúa como un comodín que coincide con cualquier secuencia de caracteres.

Al escribir *.log Git ignora cualquier archivo que termine con .log, sin importar cómo el nombre y en qué carpeta del repositorio se encuentre.